### PR TITLE
Support for pptx added

### DIFF
--- a/lib/targets.js
+++ b/lib/targets.js
@@ -28,6 +28,7 @@ module.exports = {
   'opml':               { 'ext': 'opml' },
   'org':                { 'ext': 'org' },
   // 'pdf':                { 'ext': 'pdf', 'format': 'latex' },
+  'pptx':               { 'ext': 'pptx'},
   'plain':              { 'ext': 'txt' },
   'revealjs':           { 'ext': 'html' },
   'rst':                { 'ext': 'rst' },


### PR DESCRIPTION
pptx has been added to pandoc with version 2.0.5, so the commandline argument has been added here.